### PR TITLE
_reload_scene() is using free() instead of queue_free()

### DIFF
--- a/addons/scene_manager/SceneManager.gd
+++ b/addons/scene_manager/SceneManager.gd
@@ -165,7 +165,7 @@ func _reload_scene() -> void:
 
 
 func _replace_scene(path: String) -> void:
-	_current_scene.free()
+	_current_scene.queue_free()
 	emit_signal("scene_unloaded")
 	var following_scene = ResourceLoader.load(path)
 	_current_scene = following_scene.instance()


### PR DESCRIPTION
Change to queue_free() to free() otherwise calling fade_out() too close to change_scene() results in a game crash as the object is still being locked waiting for signals to be completed. 

e.g.
```
SceneManager.fade_out()
SceneManager.change_scene(
	'res://demo/test.tscn', {
		"pattern_enter": "diagonal", 
		"pattern_leave": "curtains", 
		"invert_on_leave": false,
		"skip_fade_out": true,
	}
```

Unless you change the line to yield(SceneManager.fade_out(), "complete") or add in "yield(SceneManager, "fade_complete"). 